### PR TITLE
Adjustments in train_transcoder.py and train_sae_on_language_model.py

### DIFF
--- a/sae_training/train_sae_on_language_model.py
+++ b/sae_training/train_sae_on_language_model.py
@@ -15,6 +15,7 @@ from sae_training.sparse_autoencoder import SparseAutoencoder
 
 
 def train_sae_on_language_model(
+    cfg,  
     model: HookedTransformer,
     sparse_autoencoder: SparseAutoencoder,
     activation_store: ActivationsStore,

--- a/train_transcoder.py
+++ b/train_transcoder.py
@@ -19,7 +19,7 @@ import sys
 import numpy as np
 import wandb
 from wandb.cli.cli import offline
-
+wandb.init( project="Transcoder_Codellama_Test")
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from sae_training.config import LanguageModelSAERunnerConfig
@@ -27,9 +27,9 @@ from sae_training.utils import LMSparseAutoencoderSessionloader
 from sae_training.train_sae_on_language_model import train_sae_on_language_model
 
 def main(args):
-    lr = 4e-4  # learning rate
-    l1_coeff = 9e-7  # l1 sparsity regularization coefficient 1.4e-4
-    expansion_factor = 8
+    lr = 1e-4  # learning rate
+    l1_coeff = 2e-7  # l1 sparsity regularization coefficient 1.4e-4
+    expansion_factor = 16
 
     batch_size = 4096
     per_device_batch_size = None
@@ -98,20 +98,20 @@ def main(args):
 
         # WANDB
         log_to_wandb=True,
-        wandb_project="Transcoder_Codellama",
+        wandb_project="Transcoder_Codellama_Test",
         wandb_entity="pvs-shared",
         wandb_group=None,
         wandb_log_frequency=10,
 
         # Misc
         use_tqdm=True,
-        device="cuda:0",
+        device="cuda",
         seed=42,
         n_checkpoints=0,
-        checkpoint_path="/nfs/data/shared/codellama-transcoders",  # change as you please
+        checkpoint_path="/pfs/data5/home/hd/hd_hd/hd_pe220/codellama-transcoder",  # change as you please
         dtype=torch.float32,
         model_dtype=torch.float16,
-        model_device="cuda:1",
+        model_device="cuda",
         lazy_device_loading=False,
     )
 
@@ -128,7 +128,7 @@ def main(args):
     model, sparse_autoencoder, activations_loader = loader.load_session()
 
     # train SAE
-    sparse_autoencoder = train_sae_on_language_model(
+    sparse_autoencoder = train_sae_on_language_model(cfg,
         model, sparse_autoencoder, activations_loader,
         n_checkpoints=cfg.n_checkpoints,
         batch_size=cfg.train_batch_size,


### PR DESCRIPTION
Encountered issue on bwuni cluster that the cfg file was apparently not coorectly passed on to train_sae_on_language_model.py.
I changed this in a way that cfg is directly passed to the function. Therefore minor adjustments had to be made in train_transcoder.py and train_sae_on_language_model.py. 
Lennart asked me to change this on github, but as I dont have puh permission, I do this via this request